### PR TITLE
allow to iterate over MapSchema

### DIFF
--- a/src/colyseus/server/schema/Schema.hx
+++ b/src/colyseus/server/schema/Schema.hx
@@ -1,4 +1,5 @@
 package colyseus.server.schema;
+import haxe.Constraints;
 
 #if macro
 import haxe.macro.Context;
@@ -19,7 +20,7 @@ extern class ArraySchema<T> extends Array<T>{
 }
 
 @:jsRequire("@colyseus/schema", "MapSchema")
-extern class MapSchema<T> {
+extern class MapSchema<T> implements IMap<String, T>{
 	public function new(?items:Any);
 }
 


### PR DESCRIPTION
hi @serjek, I haven't tested this change. This is supposed to allow iterating over `MapSchema`, like it's possible in JavaScript:

```javascript
for (let key in map) {
  console.log(key, map[key]);
}
```

I'm posting this on Discord too, since Mdotedot asked about this today. Cheers!