### PR TITLE
fix warnings in haxe 4.0.0-rc.3; add haxelib.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # colyseus-hxjs
-Haxe externs for [colyseus](https://colyseus.io/) server and client to compile into js/nodejs/react/react-native projects
 
-Note that since ES6 code is required you should use haxe no earlier than 4.0.0-rc.2
+Haxe externs for [colyseus](https://colyseus.io/) server and client to compile into js/nodejs/react/react-native projects.
+
+Note that since ES6 code is required you should use haxe no earlier than 4.0.0-rc.3
 
 [Examples](https://github.com/serjek/colyseus-hxjs-examples)

--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,10 @@
+{
+    "name": "colyseus-hxjs",
+    "url": "https://github.com/serjek/colyseus-hxjs",
+    "classPath": "src",
+    "contributors": ["serjek"],
+    "description": "haxe externs for colyseus server",
+    "license": "MIT",
+    "releasenote": "",
+    "version": "0.1.0"
+}

--- a/src/colyseus/server/MatchMaker.hx
+++ b/src/colyseus/server/MatchMaker.hx
@@ -1,5 +1,5 @@
 package colyseus.server;
-import js.Promise;
+import js.lib.Promise;
 import colyseus.server.presence.*;
 import colyseus.server.matchmaker.*;
 import colyseus.server.Room;

--- a/src/colyseus/server/Room.hx
+++ b/src/colyseus/server/Room.hx
@@ -1,6 +1,6 @@
 package colyseus.server;
 import colyseus.server.presence.*;
-import js.Promise;
+import js.lib.Promise;
 
 typedef RoomConstructor = Presence->Room;
 typedef SimulationCallback = Float->Void;

--- a/src/colyseus/server/Server.hx
+++ b/src/colyseus/server/Server.hx
@@ -1,5 +1,5 @@
 package colyseus.server;
-import js.Promise;
+import js.lib.Promise;
 import colyseus.server.Room;
 import colyseus.server.matchmaker.*;
 import colyseus.server.presence.*;

--- a/src/colyseus/server/presence/Presence.hx
+++ b/src/colyseus/server/presence/Presence.hx
@@ -1,5 +1,5 @@
 package colyseus.server.presence;
-import js.Promise;
+import js.lib.Promise;
 
 typedef Presence = {
 	function subscribe(topic:String, callback:haxe.Constraints.Function):Dynamic;

--- a/src/colyseus/server/websocket/WebSocket.hx
+++ b/src/colyseus/server/websocket/WebSocket.hx
@@ -1,5 +1,5 @@
 package colyseus.server.websocket;
-import js.Error;
+import js.lib.Error;
 import js.node.http.Agent;
 import js.node.Buffer;
 import js.node.net.Socket;

--- a/src/colyseus/server/websocket/Ws.hx
+++ b/src/colyseus/server/websocket/Ws.hx
@@ -1,6 +1,6 @@
 package colyseus.server.websocket;
 import js.node.events.EventEmitter;
-import js.Error;
+import js.lib.Error;
 import js.node.Buffer;
 import js.node.http.ClientRequest;
 import js.node.http.IncomingMessage;


### PR DESCRIPTION
- `js.Error` / `js.Promise` are deprecated in rc3 and live in `js.lib` now
- i also added a `haxelib.json` file, mainly for the `classPath` property