### PR TITLE
Allow type annotation syntax for maps/array equal to the one in the official client

### DIFF
--- a/src/colyseus/server/schema/Schema.hx
+++ b/src/colyseus/server/schema/Schema.hx
@@ -77,7 +77,32 @@ class Decorator {
 
 	static function emitDecoration(params:DecoratedField) {
 		var localClass = Context.getLocalClass().get();
-		return macro ExternDecorator.type($e{params.meta.params[0]})(untyped ($i{localClass.name}).prototype, $v{params.field.name});
+
+		var schema = null;
+		if (params.meta.params.length == 1) {
+			schema = params.meta.params[0];
+		} else {
+			var key = null;
+			var value = params.meta.params[1];
+			switch (params.meta.params[0].expr) {
+				case EConst(a):
+					switch (a) {
+						case CString(str):
+							key = str;
+						default:
+					}
+				default:
+			}
+
+			schema = ${
+				{
+					pos: Context.currentPos(),
+					expr: EObjectDecl([{field: key, expr: value}])
+				}
+			}
+		}
+
+		return macro ExternDecorator.type($e{schema})(untyped ($i{localClass.name}).prototype, $v{params.field.name});
 	}
 
 	static function getDecoratedFields(fields:Array<Field>)

--- a/src/colyseus/server/schema/Schema.hx
+++ b/src/colyseus/server/schema/Schema.hx
@@ -94,10 +94,12 @@ class Decorator {
 				default:
 			}
 
-			schema = ${
-				{
-					pos: Context.currentPos(),
-					expr: EObjectDecl([{field: key, expr: value}])
+			if (key != null) { // check if key found, if not the old {map: class} syntax may be in use
+				schema = ${
+					{
+						pos: Context.currentPos(),
+						expr: EObjectDecl([{field: key, expr: value}])
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Right now the syntax is ```@:type({map: BasePlayer})```
while on the official client is: ```@:type("map", BasePlayer)```

This should fix that, old syntax should still keep working